### PR TITLE
fix(kali): add bridge-utils and enable NetworkManager managed mode

### DIFF
--- a/images/kali-linux/virt.sysprep
+++ b/images/kali-linux/virt.sysprep
@@ -1,0 +1,97 @@
+# Preserve the default kali:kali user account
+# Only clean logs and temporary files, do NOT remove user accounts
+# This allows both the built-in kali user and cloud-init to coexist
+
+# Create resolv.conf FIRST to enable DNS resolution for package installation
+# This is required because libguestfs appliance may not have valid DNS config
+write /etc/resolv.conf:nameserver 1.1.1.1
+append-line /etc/resolv.conf:nameserver 8.8.8.8
+
+update
+install cloud-init,cloud-initramfs-growroot,openssh-server,qemu-guest-agent,python3,tmux,git,vim,btop,curl,ca-certificates,xz-utils,locales,bridge-utils
+run-command systemctl enable qemu-guest-agent
+run-command systemctl enable ssh
+run-command systemctl enable cloud-init-local.service
+run-command systemctl enable cloud-init-network.service
+run-command systemctl enable cloud-config.service
+run-command systemctl enable cloud-final.service
+
+# Fix NetworkManager to manage interfaces from ifupdown/cloud-init
+# Default Kali has managed=false which breaks cloud-init network config
+run-command sed -i 's/managed=false/managed=true/' /etc/NetworkManager/NetworkManager.conf
+
+# ============================================================================
+# Phase 1.5: Locale Configuration
+# ============================================================================
+
+# Generate en_US.UTF-8 locale to prevent bash warnings
+run-command sed -i 's/^# *en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
+run-command locale-gen
+run-command update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+
+# Set system-wide locale defaults
+write /etc/default/locale:LANG=en_US.UTF-8
+append-line /etc/default/locale:LC_ALL=en_US.UTF-8
+append-line /etc/default/locale:LANGUAGE=en_US.UTF-8
+append-line /etc/default/locale:LC_CTYPE=en_US.UTF-8
+
+# ============================================================================
+# Phase 2: Mise Installation Integration
+# ============================================================================
+
+# Install mise binary (polyglot runtime manager)
+# Using direct binary download for reliability and offline capability
+run-command curl -fsSL https://github.com/jdx/mise/releases/latest/download/mise-latest-linux-x64 -o /usr/local/bin/mise
+run-command chmod 755 /usr/local/bin/mise
+run-command /usr/local/bin/mise --version
+
+# Configure mise activation in /etc/skel/.bashrc for all new users
+run-command mkdir -p /etc/skel
+append-line /etc/skel/.bashrc:
+append-line /etc/skel/.bashrc:# Locale configuration
+append-line /etc/skel/.bashrc:export LANG=en_US.UTF-8
+append-line /etc/skel/.bashrc:export LC_ALL=en_US.UTF-8
+append-line /etc/skel/.bashrc:
+append-line /etc/skel/.bashrc:# Mise (polyglot runtime manager) initialization
+append-line /etc/skel/.bashrc:# Auto-loads tools based on .mise.toml and .env files
+append-line /etc/skel/.bashrc:export PATH="$HOME/.local/bin:$PATH"
+append-line /etc/skel/.bashrc:if command -v mise >/dev/null 2>&1; then
+append-line /etc/skel/.bashrc:  eval "$(mise activate bash)"
+append-line /etc/skel/.bashrc:fi
+
+# ============================================================================
+# Phase 3: Lix/Nix Installation Integration
+# ============================================================================
+
+# Create systemd directories for Nix installer (required in chroot)
+run-command mkdir -p /run/systemd/system
+run-command mkdir -p /var/lib/systemd
+
+# Install Lix (Nix fork) in multi-user mode with systemd daemon
+# Using official Lix installer with non-interactive flag
+run-command curl -sSf -L https://install.lix.systems/lix | sh -s -- install --no-confirm
+
+# Enable nix-daemon.service to start on boot
+run-command systemctl enable nix-daemon.service
+
+# Configure Nix daemon profile in /etc/skel/.bashrc for all new users
+append-line /etc/skel/.bashrc:
+append-line /etc/skel/.bashrc:# Nix package manager initialization
+append-line /etc/skel/.bashrc:# Source the multi-user Nix daemon profile
+append-line /etc/skel/.bashrc:if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+append-line /etc/skel/.bashrc:  source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+append-line /etc/skel/.bashrc:fi
+
+# Configure kali user home directory (kali user already exists in base image)
+# Copy the updated .bashrc configuration to existing kali user
+run-command cp -n /etc/skel/.bashrc /home/kali/.bashrc || true
+run-command chown kali:kali /home/kali/.bashrc
+run-command chmod 644 /home/kali/.bashrc
+
+# Create .local/bin directory for kali user (required for mise)
+run-command mkdir -p /home/kali/.local/bin
+run-command chown -R kali:kali /home/kali/.local
+run-command chmod 755 /home/kali/.local /home/kali/.local/bin
+
+# Clean up package cache
+run-command apt-get autoremove -y && apt-get clean


### PR DESCRIPTION
## Summary
- Add bridge-utils package for ifupdown bridge interface creation
- Set NetworkManager managed=true for cloud-init eni renderer compatibility

## Problem
Kali Linux VMs deployed via KubeVirt with cloud-init bridge networking fail to get network connectivity on first boot:
1. Cloud-init eni renderer writes bridge config to /etc/network/interfaces.d/50-cloud-init
2. ifupdown fails because bridge-utils is missing (cannot create br0)
3. Even with simple eth0 DHCP, NetworkManager has managed=false for ifupdown interfaces
4. Result: VMs get link-local IPs (169.254.x.x) instead of DHCP

## Solution
1. Install bridge-utils - provides brctl for ifupdown bridge creation
2. Set managed=true in NetworkManager.conf - makes NM manage interfaces configured by cloud-init

## Test Plan
- [ ] Build Kali image with changes
- [ ] Deploy VM with bridge networking via cloud-init
- [ ] Verify br0 bridge is created and gets DHCP IP on first boot
- [ ] Deploy VM with simple eth0 DHCP
- [ ] Verify eth0 gets DHCP IP on first boot

## Summary by Sourcery

Ensure Kali Linux images configure networking correctly for cloud-init managed bridge and DHCP interfaces.

Bug Fixes:
- Fix Kali VMs failing to obtain DHCP addresses when configured via cloud-init bridge networking or simple eth0 DHCP on first boot.

Enhancements:
- Add Kali image sysprep script to install bridge-utils and enable NetworkManager managed mode for ifupdown/cloud-init interfaces.