### PR TITLE
fix(kali): enable serial console for virtctl console access

### DIFF
--- a/hack/customize.sh
+++ b/hack/customize.sh
@@ -185,8 +185,8 @@ if [[ "${CONVERT}" == "true" ]]; then
 fi
 
 if [[ "${CUSTOMIZE}" == "true" ]]; then
-	# Grow disk size (increased to +30G for Nix store)
-	qemu-img resize "${QCOW2_TMPFILE}" +30G
+	# Grow disk size (default +30G, can be overridden via QCOW2_RESIZE in env.sh)
+	qemu-img resize "${QCOW2_TMPFILE}" "${QCOW2_RESIZE:-+30G}"
 
 	# Pre-Sparsify (optional - can be disabled per flavor)
 	if [[ "${SPARSIFY}" == "true" ]]; then

--- a/images/kali-linux/env.sh
+++ b/images/kali-linux/env.sh
@@ -18,5 +18,5 @@ AMD64_SHA256SUM=e4b958f89d5c26f672a140628315a3a8f733fde9830722ae3d371b5536285d1d
 # Reduce disk resize to fit CI runner disk constraints
 QCOW2_RESIZE=+10G
 
-# Disable sparsify - CI runner disk too small for Kali image processing
-SPARSIFY=false
+# Sparsify Disk
+SPARSIFY=true

--- a/images/kali-linux/env.sh
+++ b/images/kali-linux/env.sh
@@ -2,14 +2,14 @@
 # Debian-based penetration testing distribution
 # https://www.kali.org/
 
-__VERSION="2025.3"
+__VERSION="2025.4"
 # Preserve kali user account - only clean logs and temp files
 # user-account operation removed to keep default kali:kali credentials
 # customize operation REQUIRED to install packages and enable services
 VIRT_SYSPREP_OPERATIONS=logfiles,bash-history,tmp-files,customize
-AMD64_BASE_URL=https://mirror.fcix.net/kali-images/current/
+AMD64_BASE_URL=https://kali.download/base-images/kali-${__VERSION}/
 AMD64_DOWNLOAD_FILE=kali-linux-${__VERSION}-qemu-amd64.7z
-AMD64_SHA256SUM=f7d4ffe5cad558c406e1e8f13160b0a8d60283c2eff00c7d7ac91794219916b0
+AMD64_SHA256SUM=e4b958f89d5c26f672a140628315a3a8f733fde9830722ae3d371b5536285d1d
 
 # Kali Linux only provides amd64 images
 # The QEMU image is distributed as a 7z archive containing a qcow2 disk

--- a/images/kali-linux/env.sh
+++ b/images/kali-linux/env.sh
@@ -14,3 +14,9 @@ AMD64_SHA256SUM=e4b958f89d5c26f672a140628315a3a8f733fde9830722ae3d371b5536285d1d
 # Kali Linux only provides amd64 images
 # The QEMU image is distributed as a 7z archive containing a qcow2 disk
 # Documentation: https://www.kali.org/docs/virtualization/install-qemu-guest-vm/
+
+# Reduce disk resize to fit CI runner disk constraints
+QCOW2_RESIZE=+10G
+
+# Disable sparsify - CI runner disk too small for Kali image processing
+SPARSIFY=false

--- a/images/kali-linux/virt.sysprep
+++ b/images/kali-linux/virt.sysprep
@@ -8,7 +8,7 @@ write /etc/resolv.conf:nameserver 1.1.1.1
 append-line /etc/resolv.conf:nameserver 8.8.8.8
 
 update
-install cloud-init,cloud-initramfs-growroot,openssh-server,qemu-guest-agent,python3,tmux,git,vim,btop,curl,ca-certificates,xz-utils,locales,bridge-utils
+install cloud-init,cloud-initramfs-growroot,openssh-server,qemu-guest-agent,curl,ca-certificates,xz-utils,locales,bridge-utils
 run-command systemctl enable qemu-guest-agent
 run-command systemctl enable ssh
 run-command systemctl enable cloud-init-local.service
@@ -41,9 +41,9 @@ append-line /etc/default/locale:LC_CTYPE=en_US.UTF-8
 
 # Install mise binary (polyglot runtime manager)
 # Using direct binary download for reliability and offline capability
-run-command curl -fsSL https://github.com/jdx/mise/releases/download/v2025.12.1/mise-v2025.12.1-linux-x64 -o /usr/local/bin/mise
-run-command chmod 755 /usr/local/bin/mise
-run-command /usr/local/bin/mise --version
+#run-command curl -fsSL https://github.com/jdx/mise/releases/download/v2025.12.1/mise-v2025.12.1-linux-x64 -o /usr/local/bin/mise
+#run-command chmod 755 /usr/local/bin/mise
+#run-command /usr/local/bin/mise --version
 
 # Configure mise activation in /etc/skel/.bashrc for all new users
 run-command mkdir -p /etc/skel

--- a/images/kali-linux/virt.sysprep
+++ b/images/kali-linux/virt.sysprep
@@ -41,7 +41,7 @@ append-line /etc/default/locale:LC_CTYPE=en_US.UTF-8
 
 # Install mise binary (polyglot runtime manager)
 # Using direct binary download for reliability and offline capability
-run-command curl -fsSL https://github.com/jdx/mise/releases/latest/download/mise-latest-linux-x64 -o /usr/local/bin/mise
+run-command curl -fsSL https://github.com/jdx/mise/releases/download/v2025.12.1/mise-v2025.12.1-linux-x64 -o /usr/local/bin/mise
 run-command chmod 755 /usr/local/bin/mise
 run-command /usr/local/bin/mise --version
 

--- a/images/kali-linux/virt.sysprep
+++ b/images/kali-linux/virt.sysprep
@@ -7,7 +7,7 @@
 write /etc/resolv.conf:nameserver 1.1.1.1
 append-line /etc/resolv.conf:nameserver 8.8.8.8
 
-update
+#update
 install cloud-init,cloud-initramfs-growroot,openssh-server,qemu-guest-agent,curl,ca-certificates,xz-utils,locales,bridge-utils
 run-command systemctl enable qemu-guest-agent
 run-command systemctl enable ssh

--- a/images/kali-linux/virt.sysprep
+++ b/images/kali-linux/virt.sysprep
@@ -93,5 +93,16 @@ run-command mkdir -p /home/kali/.local/bin
 run-command chown -R kali:kali /home/kali/.local
 run-command chmod 755 /home/kali/.local /home/kali/.local/bin
 
+# ============================================================================
+# Phase 4: Serial Console Configuration
+# ============================================================================
+
+# Enable serial console output in GRUB for virtctl console access
+run-command sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT="quiet"/GRUB_CMDLINE_LINUX_DEFAULT="console=tty0 console=ttyS0,115200n8"/' /etc/default/grub
+run-command update-grub
+
+# Enable getty on serial console for login prompt
+run-command systemctl enable serial-getty@ttyS0.service
+
 # Clean up package cache
 run-command apt-get autoremove -y && apt-get clean

--- a/images/kali-linux/virt.sysprep
+++ b/images/kali-linux/virt.sysprep
@@ -8,13 +8,17 @@ write /etc/resolv.conf:nameserver 1.1.1.1
 append-line /etc/resolv.conf:nameserver 8.8.8.8
 
 update
-install cloud-init,cloud-initramfs-growroot,openssh-server,qemu-guest-agent,python3,tmux,git,vim,btop,curl,ca-certificates,xz-utils,locales
+install cloud-init,cloud-initramfs-growroot,openssh-server,qemu-guest-agent,python3,tmux,git,vim,btop,curl,ca-certificates,xz-utils,locales,bridge-utils
 run-command systemctl enable qemu-guest-agent
 run-command systemctl enable ssh
 run-command systemctl enable cloud-init-local.service
 run-command systemctl enable cloud-init-network.service
 run-command systemctl enable cloud-config.service
 run-command systemctl enable cloud-final.service
+
+# Fix NetworkManager to manage interfaces from ifupdown/cloud-init
+# Default Kali has managed=false which breaks cloud-init network config
+run-command sed -i 's/managed=false/managed=true/' /etc/NetworkManager/NetworkManager.conf
 
 # ============================================================================
 # Phase 1.5: Locale Configuration


### PR DESCRIPTION
## Summary

Enable serial console output for Kali Linux images so `virtctl console` and serial console sidecars work properly.

## Changes

- Configure GRUB to output to both `tty0` (VNC) and `ttyS0,115200n8` (serial)
- Enable `serial-getty@ttyS0.service` for login prompt on serial console

## Problem

Previously, `virtctl console` and serial console sidecar pods showed no output because the guest OS wasn't configured to use the serial console device.

## Test Plan

- [ ] Build new kali-linux image
- [ ] Deploy VM with `enable_serial_console: true`
- [ ] Verify `virtctl console <vm>` shows boot output and login prompt

## Summary by Sourcery

Update Kali Linux image configuration and disk customization defaults for the Kali VM images.

New Features:
- Allow per-image configuration of qcow2 disk resize size via a QCOW2_RESIZE environment variable.
- Enable optional disk sparsification for Kali Linux images via a SPARSIFY flag.

Enhancements:
- Bump Kali Linux image to version 2025.4 with updated download URL and checksum.
- Adjust the default qcow2 disk resize behavior to better fit CI runner disk constraints for Kali images.