### PR TITLE
feat(kali): enable serial console for virtctl console access

### DIFF
--- a/images/kali-linux/virt.sysprep
+++ b/images/kali-linux/virt.sysprep
@@ -93,5 +93,16 @@ run-command mkdir -p /home/kali/.local/bin
 run-command chown -R kali:kali /home/kali/.local
 run-command chmod 755 /home/kali/.local /home/kali/.local/bin
 
+# ============================================================================
+# Phase 4: Serial Console Configuration
+# ============================================================================
+
+# Enable serial console output in GRUB for virtctl console access
+run-command sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT="quiet"/GRUB_CMDLINE_LINUX_DEFAULT="console=tty0 console=ttyS0,115200n8"/' /etc/default/grub
+run-command update-grub
+
+# Enable getty on serial console for login prompt
+run-command systemctl enable serial-getty@ttyS0.service
+
 # Clean up package cache
 run-command apt-get autoremove -y && apt-get clean


### PR DESCRIPTION
## Summary

Enable serial console output for Kali Linux images so `virtctl console` and serial console sidecars work properly.

## Changes

- Configure GRUB to output to both `tty0` (VNC) and `ttyS0,115200n8` (serial)
- Enable `serial-getty@ttyS0.service` for login prompt on serial console

## Problem

Previously, `virtctl console` and serial console sidecar pods showed no output because the guest OS wasn't configured to use the serial console device.

## Test Plan

- [ ] Build new kali-linux image
- [ ] Deploy VM with `enable_serial_console: true`
- [ ] Verify `virtctl console <vm>` shows boot output and login prompt

## Summary by Sourcery

Enable serial console support for Kali Linux VM images to allow virtctl console access and serial sidecars to display boot and login output.

Enhancements:
- Configure Kali Linux GRUB to output to both VNC and serial consoles for proper console visibility.
- Enable a serial getty service on ttyS0 to provide a login prompt over the serial console.